### PR TITLE
Adding "fooof_get_model" to provide easier access to getting the actual model fit

### DIFF
--- a/matlab_wrapper/fooof.m
+++ b/matlab_wrapper/fooof.m
@@ -49,8 +49,8 @@ function fooof_results = fooof(freqs, psd, f_range, settings)
     % Run FOOOF fit
     fm.fit(freqs, psd, f_range)
 
-    
     % Extract outputs
-    fooof_results = fooof_unpack_results(fm);
+    fooof_results = fm.get_results();
+    fooof_results = fooof_unpack_results(fooof_results);
     
 end

--- a/matlab_wrapper/fooof_get_model.m
+++ b/matlab_wrapper/fooof_get_model.m
@@ -1,0 +1,7 @@
+function model_out = fooof_get_model(fm)
+
+    model_out = struct();
+    
+    model_out.fooof_freqs = double(py.array.array('d',fm.freqs));
+    model_out.power_spectrum = double(py.array.array('d', fm.power_spectrum));
+    model_out.fooof_spectrum = double(py.array.array('d', fm.fooofed_spectrum_));

--- a/matlab_wrapper/fooof_get_model.m
+++ b/matlab_wrapper/fooof_get_model.m
@@ -1,7 +1,9 @@
+% Get the actual fit model from a FOOOF object
 function model_out = fooof_get_model(fm)
 
     model_out = struct();
     
-    model_out.fooof_freqs = double(py.array.array('d',fm.freqs));
+    model_out.freqs = double(py.array.array('d',fm.freqs));
     model_out.power_spectrum = double(py.array.array('d', fm.power_spectrum));
-    model_out.fooof_spectrum = double(py.array.array('d', fm.fooofed_spectrum_));
+    model_out.fooofed_spectrum = double(py.array.array('d', fm.fooofed_spectrum_));
+    model_out.bg_fit = double(py.array.array('d', py.getattr(fm, '_bg_fit')));

--- a/matlab_wrapper/fooof_unpack_results.m
+++ b/matlab_wrapper/fooof_unpack_results.m
@@ -1,18 +1,6 @@
 % Unpack fooof_results python object into matlab struct
-function results_out = fooof_unpack_results(fm)
+function results_out = fooof_unpack_results(results_in)
 
-    results_out = struct();
-    
-    results_out.fooof_freqs = double(py.array.array('d',fm.freqs));
-    results_out.power_spectrum = double(py.array.array('d', fm.power_spectrum));
-    results_out.fooof_spectrum = double(py.array.array('d', fm.fooofed_spectrum_));
-    
-    %This still gives error in matlab due to the variable starting with undefined character
-    % results_out.fooof_bg_fit = double(py.array.array('d',fm._bg_fit));
-    % results_out.fooof_bg_fit = double(py.array.array('d',getfield(fm,'_bg_fit')));
-     
-    results_in = fm.get_results();
-    
     results_out.background_params = ...
         double(py.array.array('d', results_in.background_params));
     
@@ -27,7 +15,9 @@ function results_out = fooof_unpack_results(fm)
     results_out.error = ...
         double(py.array.array('d', py.numpy.nditer(results_in.error)));
     
-    % Note: for reasons unknown, r_squared seems to come out as float...
+    % Note: r_squared seems to come out as float
+    %   It's not clear why this value is different, but doesn't seem
+    %   to require the type casting like other (code commented below)
     results_out.r_squared = results_in.r_squared;
     %results_out.r_squared = ...
     %    double(py.array.array('d', py.numpy.nditer(results_in.r_squared)));

--- a/matlab_wrapper/fooof_unpack_results.m
+++ b/matlab_wrapper/fooof_unpack_results.m
@@ -1,6 +1,8 @@
 % Unpack fooof_results python object into matlab struct
 function results_out = fooof_unpack_results(results_in)
 
+    results_out = struct();
+
     results_out.background_params = ...
         double(py.array.array('d', results_in.background_params));
     


### PR DESCRIPTION
updating the matlab wrapper to also return the values of:

- fooofeed_freq
- fooofed_spectrum

I also tried retrieving ` _bg_fit` but since the variable name starts with `_` ( not allowed in matlab); one cannot use it directly in the form of `fm._bg_fit`. Is there any other way to fetch it? maybe from flattened_spectrum